### PR TITLE
Add sans-serif as fallback font for h1

### DIFF
--- a/src/css/components/_core.scss
+++ b/src/css/components/_core.scss
@@ -14,7 +14,7 @@ body {
 }
 
 h1 {
-  font-family: 'Roboto';
+  font-family: Roboto, sans-serif;
   font-size: 3rem;
   font-weight: 400;
   text-align: center;


### PR DESCRIPTION
- Fixes missing fallback font for the h1 title:

![Screen Shot 2021-02-18 at 9 59 20 PM](https://user-images.githubusercontent.com/4544770/108375502-98a8d780-7234-11eb-8a8c-81583aca72ef.png)
