### PR TITLE
Fix display for past releases

### DIFF
--- a/src/js/lib/utils.ts
+++ b/src/js/lib/utils.ts
@@ -59,7 +59,7 @@ export function readableDate(releases: NodeListOf<HTMLElement>): void {
 
   for (const release of releases) {
     const d = new Date(release.dataset.date);
-    const diff = Math.abs(Math.ceil((Number(d) - Number(today)) / (1000 * 60 * 60 * 24)));
+    const diff = Math.ceil((Number(d) - Number(today)) / (1000 * 60 * 60 * 24));
     const short = d.toLocaleDateString('en-us', {
       year: 'numeric',
       month: 'short',
@@ -67,9 +67,9 @@ export function readableDate(releases: NodeListOf<HTMLElement>): void {
     });
 
     if (diff < 0) {
-      release.innerHTML = `Stable ${diff.toLocaleString()} days ago <br/>(${short})`;
+      release.innerHTML = `Stable ${Math.abs(diff).toLocaleString()} days ago <br/>(${short})`;
     } else {
-      release.innerHTML = `Stable in ${diff.toLocaleString()} days <br/>(${short})`;
+      release.innerHTML = `Stable in ${Math.abs(diff).toLocaleString()} days <br/>(${short})`;
     }
   }
 }


### PR DESCRIPTION
Looks like I introduced a bug in #13: I make the number an absolute number too early, so the correct text "Stable X days ago" is no longer displayed for past releases. This PR fixes that by making the number absolute _after_ checking for the sign.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR