### PR TITLE
Fix release display for three-digit version numbers

### DIFF
--- a/src/css/list.scss
+++ b/src/css/list.scss
@@ -7,7 +7,7 @@
   width: 100%;
   justify-content: center;
   flex-wrap: wrap;
-  max-width: 115ch;
+  max-width: 125ch;
   position: relative;
 }
 


### PR DESCRIPTION
Release versions currently wrap to a new line due to three-digit version numbers.

![image](https://user-images.githubusercontent.com/6698344/150769967-0e960a81-c57d-4f25-95f4-0d4ecc3e1f27.png)

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR