### PR TITLE
Sort API platforms alphabetically

### DIFF
--- a/data/bugs.js
+++ b/data/bugs.js
@@ -221,7 +221,7 @@ module.exports = async function () {
       }
 
       if (where.length) {
-        result.where = where;
+        result.where = where.sort();
       }
 
       // Determine if it's PWA related


### PR DESCRIPTION
Sorts API platforms alphabetically (currently it's more or less random: https://github.com/GoogleChromeLabs/fugu-tracker/blob/main/data/bugs.js#L152).

- [ ] Tests pass - **N/A**
- [ ] Appropriate changes to README are included in PR - **N/A**