### PR TITLE
Handle null chromium bugs

### DIFF
--- a/data/bugs.js
+++ b/data/bugs.js
@@ -254,8 +254,12 @@ module.exports = async function () {
         result.iwa = true;
       }
 
-      // Determine if it has a Chrome Status feature entry, and update as needed
-      const feature = features.find((f) => get(f, 'browsers.chrome.bug', '').includes(result.id));
+      // Determine if it has a Chrome Status feature entry, and update as needed      
+      const feature = features.find((f) => {
+        const chromeBug = get(f, 'browsers.chrome.bug', '') || '';
+        return chromeBug.includes(result.id);
+      });
+
       let docs = [];
       let demos = [];
       let explainers = [];

--- a/data/bugs.js
+++ b/data/bugs.js
@@ -254,7 +254,7 @@ module.exports = async function () {
         result.iwa = true;
       }
 
-      // Determine if it has a Chrome Status feature entry, and update as needed      
+      // Determine if it has a Chrome Status feature entry, and update as needed
       const feature = features.find((f) => {
         const chromeBug = get(f, 'browsers.chrome.bug', '') || '';
         return chromeBug.includes(result.id);


### PR DESCRIPTION
Fugu track deployments started to fail recently. See https://github.com/GoogleChromeLabs/fugu-tracker/actions/runs/3579091607/jobs/6019917593#step:6:56

This PR fixes this by handling `null` chromium bugs. The "Standby API" for instance had one: https://chromestatus.com/features#standby